### PR TITLE
Add Serial1 ESP-8266 UART to FleaFPGA-Uno

### DIFF
--- a/hardware/fpga/f32c/variants/FleaFPGA-Uno/variant.h
+++ b/hardware/fpga/f32c/variants/FleaFPGA-Uno/variant.h
@@ -171,7 +171,7 @@ static const uint8_t PWM1  = 15;
 #include "UARTClass.h"
 
 extern UARTClass Serial;			// FTDI USB UART
-//TODO: Xark - 2nd UART extern UARTClass<IO_SIO_BYTE_1, IO_SIO_STATUS_1, IO_SIO_BAUD_1> Serial1;	// ESP-8266 UART
+extern UARTClass Serial1;			// Optional ESP-8266 WiFi UART
 #endif
 
 #endif /* _f32c_mips_variant_h */


### PR DESCRIPTION
This adds a parameter to UARTClass to allow specifying the SIO register
to use (defaults to main SIO port so other boards should not be
affected).  It also adds a default Serial1 object for FleaFPGA-Uno
variant (which uses this dedicated UART to talk to optional ESP-8266
WiFi).  Allows easy support of as many UARTs as configured on a board.
