### PR TITLE
Minor warning fixes for IDE 1.6.7

### DIFF
--- a/libraries/f32c_VGATextConsole/examples/f32c_TwoColorBMapTest/f32c_TwoColorBMapTest.ino
+++ b/libraries/f32c_VGATextConsole/examples/f32c_TwoColorBMapTest/f32c_TwoColorBMapTest.ino
@@ -11,7 +11,7 @@ void drawRLE();
 uint8_t fb[FB_WIDTH * FB_HEIGHT] __attribute__ ((aligned (4)));
 //uint8_t *fb = (uint8_t *)0x80060000;
 
-static inline void plot(int x, int y, int color)
+inline void plot(int x, int y, int color)
 {
   uint32_t off = (y * FB_WIDTH) + (x>>3);
   if (off < (FB_WIDTH * FB_HEIGHT))

--- a/libraries/f32c_VGATextConsole/examples/f32c_VGAConsoleFeatures/f32c_VGAConsoleFeatures.ino
+++ b/libraries/f32c_VGATextConsole/examples/f32c_VGAConsoleFeatures/f32c_VGAConsoleFeatures.ino
@@ -215,7 +215,7 @@ void setup() {
   }
 
   wait(10);
-  memcpy(vga.GetTextAddress(), 0x80000000, vga.width * vga.height * (vga.IsMonochromeConfigured() ? 1 : 2));
+  memcpy(vga.GetTextAddress(), (void *)0x80000000, vga.width * vga.height * (vga.IsMonochromeConfigured() ? 1 : 2));
   vga.SetPos(15, 10);
   vga.print("(Set to garbage on purpose to see full characters)");
   

--- a/libraries/f32c_VGATextConsole/examples/f32c_VGAConsoleTest/f32c_VGAConsoleTest.ino
+++ b/libraries/f32c_VGATextConsole/examples/f32c_VGAConsoleTest/f32c_VGAConsoleTest.ino
@@ -11,7 +11,7 @@ void drawRLE();
 //uint8_t fb[FB_WIDTH * FB_HEIGHT] __attribute__ ((aligned (4)));
 uint8_t *fb = (uint8_t) 0x81f00000;
 
-static inline void plot(int x, int y, int color)
+inline void plot(int x, int y, int color)
 {
   uint32_t off = (y * FB_WIDTH) + x;
   if (off < sizeof (fb))


### PR DESCRIPTION
Fix a few warnings that show up with IDE 1.6.7 (with warnings enabled).
The void one is my fault, but not fully clear why the static inline was
a problem (I suspect IDE preprocessing glitch), but the static wasn't
really needed.
